### PR TITLE
finish VPATH -> vpath translation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifneq ($(wildcard config-host.mak),)
 all: build-all
 include config-host.mak
 include $(SRC_PATH)/rules.mak
-config-host.mak: configure
+config-host.mak: $(SRC_PATH)/configure
 	@echo $@ is out-of-date, running configure
 	@sed -n "/.*Configured with/s/[^:]*: //p" $@ | sh
 else

--- a/Makefile.target
+++ b/Makefile.target
@@ -333,7 +333,7 @@ $(QEMU_PROG): $(obj-y) $(obj-$(TARGET_BASE_ARCH)-y)
 	$(call LINK,$(obj-y) $(obj-$(TARGET_BASE_ARCH)-y))
 
 
-gdbstub-xml.c: $(TARGET_XML_FILES) feature_to_c.sh
+gdbstub-xml.c: $(TARGET_XML_FILES) $(SRC_PATH)/feature_to_c.sh
 	$(call quiet-command,rm -f $@ && $(SHELL) $(SRC_PATH)/feature_to_c.sh $@ $(TARGET_XML_FILES),"  GEN   $(TARGET_DIR)$@")
 
 qemu-options.h: $(SRC_PATH)/qemu-options.hx

--- a/configure
+++ b/configure
@@ -1991,9 +1991,6 @@ qemu_version=`head $source_path/VERSION`
 echo "VERSION=$qemu_version" >>$config_host_mak
 echo "PKGVERSION=$pkgversion" >>$config_host_mak
 echo "SRC_PATH=$source_path" >> $config_host_mak
-if [ "$source_path_used" = "yes" ]; then
-  echo "VPATH=$source_path" >> $config_host_mak
-fi
 echo "TARGET_DIRS=$target_list" >> $config_host_mak
 if [ "$docs" = "yes" ] ; then
   echo "BUILD_DOCS=yes" >> $config_host_mak

--- a/rules.mak
+++ b/rules.mak
@@ -39,7 +39,8 @@ quiet-command = $(if $(V),$1,$(if $(2),@echo $2 && $1, @$1))
 cc-option = $(if $(shell $(CC) $1 $2 -S -o /dev/null -xc /dev/null \
               >/dev/null 2>&1 && echo OK), $2, $3)
 
-set-vpath = $(if $1,$(foreach PATTERN,%.c %.h %.S, $(eval vpath $(PATTERN) $1)))
+VPATH_SUFFIXES = %.c %.h %.S %.m %.mak %.texi
+set-vpath = $(if $1,$(foreach PATTERN,$(VPATH_SUFFIXES), $(eval vpath $(PATTERN) $1)))
 
 # Generate timestamp files for .h include files
 


### PR DESCRIPTION
This adds a few more vpath suffixes and points the remaining two paths
explicitly to $(SRC_PATH) in order to eliminate the VPATH assignment
from config-host.mak.

Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
Cc: Juan Quintela <quintela@redhat.com>
Signed-off-by: Anthony Liguori <aliguori@us.ibm.com>